### PR TITLE
Remove double entry for python-dateutil

### DIFF
--- a/lnx_requirements.txt
+++ b/lnx_requirements.txt
@@ -10,6 +10,5 @@ pyudev==0.15
 pyxattr==0.5.1
 PIL==1.1.7
 pyreadline==2.1
-python-dateutil==1.5
 readline==6.2.4.1
 requests==2.12.2


### PR DESCRIPTION
There are two versions of python-dateutil inside lnx_requirements.txt => 2.5.3 and 1.5
Remove older version entry so that 'pip' install requirements without any issues.

$ pip install -r lnx_requirements.txt
Double requirement given: python-dateutil==1.5 (from -r lnx_requirements.txt (line 13)) (already in python-dateutil==2.5.3 (from -r lnx_requirements.txt (line 7)), name='python-dateutil')