### PR TITLE
docs: fix simple typo, plateform -> platform

### DIFF
--- a/Configuration/mss/factory.py
+++ b/Configuration/mss/factory.py
@@ -12,7 +12,7 @@ from .exception import ScreenshotError
 def mss(*args, **kwargs):
     ''' Factory returning a proper MSS class instance.
 
-        It detects the plateform we are running on
+        It detects the platform we are running on
         and choose the most adapted mss_class to take
         screenshots.
 


### PR DESCRIPTION
There is a small typo in Configuration/mss/factory.py.

Should read `platform` rather than `plateform`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md